### PR TITLE
Remove Ewok/Docker step

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 - Step 5. Ignore Step 5
 - Step 6. If an open source project click 'Make my app public'
 - Create
-- Goto Settings
-  - Scroll down to Infrastructure Stack
-  - Select Ewok (5) from the dropdown.
+
 
 # Code coverage reports with [Codecov](https://codecov.io)
 


### PR DESCRIPTION
I believe this is the default now.  I didn't see the option this time.  

And when I went into Wercker's repo options afterwards, this is what I saw

![image](https://cloud.githubusercontent.com/assets/1372890/12214300/1e3e15f6-b654-11e5-8eae-33f5633d30a4.png)

As a [reminder](http://devcenter.wercker.com/docs/faq/migration-tips-v2.html):

> What is this Docker-based stack (Ewok)?
> 
> Ewok is the code name of our new Docker stack. Instead of Linux containers you can now use Docker containers for your build and deploy pipelines. You can pull and push containers from the Docker Hub or from privates registries.
